### PR TITLE
Discarding the master/slave jargon

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -10,32 +10,32 @@ rootpath = os.path.split(os.path.dirname(os.path.abspath(__file__)))[0]
 sys.path.append(rootpath)
 
 from mysql.replicant.commands import (
-    fetch_master_pos,
-    fetch_slave_pos,
+    fetch_main_pos,
+    fetch_subordinate_pos,
     )
 
 from mysql.replicant.errors import (
-    NotMasterError,
-    NotSlaveError,
+    NotMainError,
+    NotSubordinateError,
     )
 
 import my_deployment
 
 print "# Executing 'show databases'"
-for db in my_deployment.master.sql("show databases"):
+for db in my_deployment.main.sql("show databases"):
     print db["Database"]
 
 print "# Executing 'ls'"
-for line in my_deployment.master.ssh(["ls"]):
+for line in my_deployment.main.ssh(["ls"]):
     print line
 
 try:
-    print "Master position is:", fetch_master_pos(my_deployment.master)
-except NotMasterError:
-    print my_deployment.master.name, "is not configured as a master"
+    print "Main position is:", fetch_main_pos(my_deployment.main)
+except NotMainError:
+    print my_deployment.main.name, "is not configured as a main"
 
-for slave in my_deployment.slaves:
+for subordinate in my_deployment.subordinates:
     try:
-        print "Slave position is:", fetch_slave_pos(slave)
-    except NotSlaveError:
-        print slave.name, "not configured as a slave"
+        print "Subordinate position is:", fetch_subordinate_pos(subordinate)
+    except NotSubordinateError:
+        print subordinate.name, "not configured as a subordinate"

--- a/examples/load_balancer.py
+++ b/examples/load_balancer.py
@@ -58,7 +58,7 @@ class TestLoadBalancer(unittest.TestCase):
     "Class to test the load balancer functions."
 
     def setUp(self):
-        from my_deployment import common, master, slaves
+        from my_deployment import common, main, subordinates
         common.sql("DROP DATABASE IF EXISTS common")
         common.sql("CREATE DATABASE common")
         common.sql(_CREATE_TABLE)
@@ -70,23 +70,23 @@ class TestLoadBalancer(unittest.TestCase):
         common.sql("DROP DATABASE common")
 
     def testServers(self):
-        from my_deployment import common, master, slaves
+        from my_deployment import common, main, subordinates
 
         try:
-            pool_add(common, master, ['READ', 'WRITE'])
+            pool_add(common, main, ['READ', 'WRITE'])
         except AlreadyInPoolError:
-            pool_set(common, master, ['READ', 'WRITE'])
+            pool_set(common, main, ['READ', 'WRITE'])
 
-        for slave in slaves:
+        for subordinate in subordinates:
             try:
-                pool_add(common, slave, ['READ'])
+                pool_add(common, subordinate, ['READ'])
             except AlreadyInPoolError:
-                pool_set(common, slave, ['READ'])
+                pool_set(common, subordinate, ['READ'])
 
         for row in common.sql("SELECT * FROM nodes", db="common"):
-            if row['port'] == master.port:
+            if row['port'] == main.port:
                 self.assertEqual(row['type'], 'READ,WRITE')
-            elif row['port'] in [slave.port for slave in slaves]:
+            elif row['port'] in [subordinate.port for subordinate in subordinates]:
                 self.assertEqual(row['type'], 'READ')
 
 if __name__ == '__main__':

--- a/examples/my_deployment.py
+++ b/examples/my_deployment.py
@@ -17,7 +17,7 @@ from mysql.replicant.config import (
     ConfigManagerFile,
 )
 
-servers = [Server('master',
+servers = [Server('main',
                   server_id=1,
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
@@ -25,25 +25,25 @@ servers = [Server('master',
                   port=3307,
                   socket='/var/run/mysqld/mysqld1.sock',
                   ),
-           Server('slave1', server_id=2,
+           Server('subordinate1', server_id=2,
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
                   machine=Linux(),
                   port=3308,
                   socket='/var/run/mysqld/mysqld2.sock'),
-           Server('slave2', 
+           Server('subordinate2', 
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
                   machine=Linux(),
                   port=3309,
                   socket='/var/run/mysqld/mysqld3.sock'),
-           Server('slave3',
+           Server('subordinate3',
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
                   machine=Linux(),
                   port=3310,
                   socket='/var/run/mysqld/mysqld4.sock')]
 
-master = servers[0]
+main = servers[0]
 common = servers[0]              # Where the common database is stored
-slaves = servers[1:]
+subordinates = servers[1:]

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -13,23 +13,23 @@ from mysql.replicant.server import (
     User,
     )
 from mysql.replicant.roles import (
-    Master,
+    Main,
     Final,
     )
 from mysql.replicant.commands import (
-    change_master,
+    change_main,
     )
 
-master_role = Master(User("repl_user", "xyzzy"))
-final_role = Final(my_deployment.master)
+main_role = Main(User("repl_user", "xyzzy"))
+final_role = Final(my_deployment.main)
 
 try:
-    master_role.imbue(my_deployment.master)
+    main_role.imbue(my_deployment.main)
 except IOError, e:
-    print "Cannot imbue master with Master role:", e
+    print "Cannot imbue main with Main role:", e
 
-for slave in my_deployment.slaves:
+for subordinate in my_deployment.subordinates:
     try:
-        final_role.imbue(slave)
+        final_role.imbue(subordinate)
     except IOError, e:
-        print "Cannot imbue slave with Final role:", e
+        print "Cannot imbue subordinate with Final role:", e

--- a/lib/mysql/replicant/backup.py
+++ b/lib/mysql/replicant/backup.py
@@ -35,7 +35,7 @@ class PhysicalBackup(BackupImage):
     def backup_server(self, server, database="*"):
 
         from mysql.replicant.commands import (
-            fetch_master_position,
+            fetch_main_position,
             )
 
         datadir = server.fetch_config().get('datadir')
@@ -43,7 +43,7 @@ class PhysicalBackup(BackupImage):
             database = [d for d in os.listdir(datadir)
                   if os.path.isdir(os.path.join(datadir, d))]
         server.sql("FLUSH TABLES WITH READ LOCK")
-        position = fetch_master_position(server)
+        position = fetch_main_position(server)
         if server.host != "localhost":
             path = os.path.basename(self.url.path)
         else:

--- a/lib/mysql/replicant/errors.py
+++ b/lib/mysql/replicant/errors.py
@@ -22,17 +22,17 @@ class NoOptionError(Error):
     "Exception raised when ConfigManager does not find the option"
     pass
 
-class SlaveNotRunningError(Error):
-    "Exception raised when slave is not running but were expected to run"
+class SubordinateNotRunningError(Error):
+    "Exception raised when subordinate is not running but were expected to run"
     pass
 
-class NotMasterError(Error):
-    """Exception raised when the server is not a master and the
+class NotMainError(Error):
+    """Exception raised when the server is not a main and the
     operation is illegal."""
     pass
 
-class NotSlaveError(Error):
-    """Exception raised when the server is not a slave and the
+class NotSubordinateError(Error):
+    """Exception raised when the server is not a subordinate and the
     operation is illegal."""
     pass
 

--- a/lib/tests/deployment/simple.py
+++ b/lib/tests/deployment/simple.py
@@ -7,7 +7,7 @@
 from mysql.replicant.server import Server
 from mysql.replicant.common import User
 from mysql.replicant.machine import Linux
-from mysql.replicant.roles import Master, Final
+from mysql.replicant.roles import Main, Final
 
 import time, os.path
 
@@ -37,18 +37,18 @@ def _cnf(name):
     test_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(test_dir, '..', name + ".cnf")
 
-master = Server(server_id=1, name="mysqld1",
+main = Server(server_id=1, name="mysqld1",
                 sql_user=_replicant_user,
                 ssh_user=User("mysql"),
-                machine=Linux(), role=Master(_repl_user),
+                machine=Linux(), role=Main(_repl_user),
                 port=3307,
                 socket='/var/run/mysqld/mysqld1.sock',
                 defaults_file=_cnf("mysqld1"),
                 config_section="mysqld1")
-slaves = [Server(server_id=2, name="mysqld2",
+subordinates = [Server(server_id=2, name="mysqld2",
                  sql_user=_replicant_user,
                  ssh_user=User("mysql"),
-                 machine=Linux(), role=Final(master),
+                 machine=Linux(), role=Final(main),
                  port=3308,
                  socket='/var/run/mysqld/mysqld2.sock',
                  defaults_file=_cnf("mysqld2"),
@@ -56,7 +56,7 @@ slaves = [Server(server_id=2, name="mysqld2",
           Server(server_id=3, name="mysqld3",
                  sql_user=_replicant_user,
                  ssh_user=User("mysql"),
-                 machine=Linux(), role=Final(master),
+                 machine=Linux(), role=Final(main),
                  port=3309,
                  socket='/var/run/mysqld/mysqld3.sock',
                  defaults_file=_cnf("mysqld3"),
@@ -64,9 +64,9 @@ slaves = [Server(server_id=2, name="mysqld2",
           Server(server_id=4, name="mysqld4",
                  sql_user=_replicant_user,
                  ssh_user=User("mysql"),
-                 machine=Linux(), role=Final(master),
+                 machine=Linux(), role=Final(main),
                  port=3310,
                  socket='/var/run/mysqld/mysqld4.sock',
                  defaults_file=_cnf("mysqld4"),
                  config_section="mysqld4")]
-servers = [master] + slaves
+servers = [main] + subordinates

--- a/lib/tests/test_backup.py
+++ b/lib/tests/test_backup.py
@@ -23,22 +23,22 @@ class TestBackup(unittest.TestCase):
     def __init__(self, methodName, options={}):
         super(TestBackup, self).__init__(methodName)
         my = tests.utils.load_deployment(options['deployment'])
-        self.master = my.master
+        self.main = my.main
 
     def setUp(self):
         self.backup = PhysicalBackup("file:/tmp/backup.tar.gz")
         
     def testPhysicalBackup(self):
-        self.master.sql("CREATE TABLE IF NOT EXISTS dummy (a INT)", db="test")
-        self.master.sql("INSERT INTO dummy VALUES (1),(2)", db="test")
-        for row in self.master.sql("SELECT * FROM dummy", db="test"):
+        self.main.sql("CREATE TABLE IF NOT EXISTS dummy (a INT)", db="test")
+        self.main.sql("INSERT INTO dummy VALUES (1),(2)", db="test")
+        for row in self.main.sql("SELECT * FROM dummy", db="test"):
             self.assertTrue(row['a'] in [1, 2])
-        self.backup.backup_server(self.master, ['test'])
-        self.master.sql("DROP TABLE dummy", db="test")
-        self.backup.restore_server(self.master)
-        tbls = self.master.sql("SHOW TABLES", db="test")
+        self.backup.backup_server(self.main, ['test'])
+        self.main.sql("DROP TABLE dummy", db="test")
+        self.backup.restore_server(self.main)
+        tbls = self.main.sql("SHOW TABLES", db="test")
         self.assertTrue('dummy' in [t["Tables_in_test"] for t in tbls])
-        self.master.sql("DROP TABLE dummy", db="test")
+        self.main.sql("DROP TABLE dummy", db="test")
 
 def suite(options={}):
     if not options['deployment']:

--- a/lib/tests/test_basic.py
+++ b/lib/tests/test_basic.py
@@ -28,9 +28,9 @@ class TestPosition(unittest.TestCase):
         
     def testSimple(self):
         from mysql.replicant.server import Position
-        positions = [Position('master-bin.00001', 4711),
-                     Position('master-bin.00001', 9393),
-                     Position('master-bin.00002', 102)]
+        positions = [Position('main-bin.00001', 4711),
+                     Position('main-bin.00001', 9393),
+                     Position('main-bin.00002', 102)]
  
         for position in positions:
             self._checkPos(position)

--- a/lib/tests/test_config.py
+++ b/lib/tests/test_config.py
@@ -30,8 +30,8 @@ class TestConfigFile(unittest.TestCase):
 
         self.assertEqual(config.get('user'), 'mysql')
         self.assertEqual(config.get('log-bin'),
-                         '/var/log/mysql/master-bin')
-        self.assertEqual(config.get('slave-skip-start'), None)
+                         '/var/log/mysql/main-bin')
+        self.assertEqual(config.get('subordinate-skip-start'), None)
 
     def testFetchReplace(self):
         "Fetching a configuration file, adding some options, and replacing it"

--- a/lib/tests/test_roles.py
+++ b/lib/tests/test_roles.py
@@ -21,9 +21,9 @@ class TestRoles(unittest.TestCase):
     def __init__(self, methodName, options):
         super(TestRoles, self).__init__(methodName)
         my = tests.utils.load_deployment(options['deployment'])
-        self.master = my.master
-        self.slave = my.slaves[0]
-        self.slaves = my.slaves
+        self.main = my.main
+        self.subordinate = my.subordinates[0]
+        self.subordinates = my.subordinates
 
     def setUp(self):
         pass
@@ -32,22 +32,22 @@ class TestRoles(unittest.TestCase):
         # We are likely to get an IOError because we cannot write the
         # configuration file, but this is OK.
         try:
-            role.imbue(self.master)
+            role.imbue(self.main)
         except IOError:
             pass
 
-    def testMasterRole(self):
-        "Test how the master role works"
+    def testMainRole(self):
+        "Test how the main role works"
         user = mysql.replicant.server.User("repl_user", "xyzzy")
-        self._imbueRole(mysql.replicant.roles.Master(user))
+        self._imbueRole(mysql.replicant.roles.Main(user))
         
-    def testSlaveRole(self):
-        "Test that the slave role works"
-        self._imbueRole(mysql.replicant.roles.Final(self.master))
+    def testSubordinateRole(self):
+        "Test that the subordinate role works"
+        self._imbueRole(mysql.replicant.roles.Final(self.main))
 
     def testRelayRole(self):
-        "Test that the slave role works"
-        self._imbueRole(mysql.replicant.roles.Relay(self.master))
+        "Test that the subordinate role works"
+        self._imbueRole(mysql.replicant.roles.Relay(self.main))
 
 def suite(options={}):
     if not options['deployment']:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.